### PR TITLE
wrangler-actionでwrangler 4を使用するように修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,3 +16,4 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: "4"


### PR DESCRIPTION
## 概要

GitHub ActionsのCloudflare Workersデプロイワークフローで、Wranglerのバージョンを明示的に4に指定することで、デプロイ失敗を解決しました。

## 背景・課題

GitHub Actionsでのデプロイが以下のエラーで失敗していました。

```
Missing entry-point: The entry-point should be specified via the command line or the 'main' config field.
```

原因は、`wrangler-action@v3`がデフォルトでWrangler 3.90.0をインストールするのに対し、プロジェクトの設定ファイル`wrangler.jsonc`はWrangler 4系でのみ認識される形式であったためです。Wrangler 3系は`.jsonc`形式を認識できず、エントリーポイントの設定を読み込めませんでした。

## 変更内容

`.github/workflows/deploy.yml`に以下のパラメータを追加：

```yaml
wranglerVersion: "4"
```

これにより、wrangler-actionが使用するWranglerのバージョンを4系に固定し、`wrangler.jsonc`が正しく認識されるようになります。

## 確認方法

1. このPRをマージ後、`main`ブランチへのpushでワークフローが自動実行される
2. GitHub Actionsの`Deploy to Cloudflare Workers`ワークフローが正常に完了することを確認
3. デプロイされたWorkerが正常に動作することを確認