### PR TITLE
wranglerVersionを4.4.0に固定してデプロイエラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,4 +16,4 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: "4"
+          wranglerVersion: "4.4.0"


### PR DESCRIPTION
## 概要

Cloudflare Workersへのデプロイ時に発生していたエラーを修正するため、wrangler-actionで使用するwranglerのバージョンを明示的に4.4.0に固定しました。

## 変更内容

- `.github/workflows/deploy.yml`の`wranglerVersion`を`"4"`から`"4.4.0"`に変更

## 変更理由

wrangler-actionで`wranglerVersion: "4"`のように曖昧なバージョン指定をしていた場合、最新のv4系マイナーバージョンが使用される可能性があり、バージョンアップに伴う破壊的変更やバグによってデプロイが失敗するリスクがありました。

バージョンを`4.4.0`に固定することで、デプロイ環境を安定化し、予期しないエラーを防止します。