### PR TITLE
thread-reply.shをハイブリッド方式に修正してパイプ入力の問題を解決

### DIFF
--- a/.claude/skills/github/scripts/thread-reply.sh
+++ b/.claude/skills/github/scripts/thread-reply.sh
@@ -62,11 +62,7 @@ elif [[ ! -t 0 ]]; then
     # 標準入力がパイプまたはリダイレクトの場合
     COMMENT_BODY=""
     while IFS= read -r line || [[ -n "$line" ]]; do
-        if [[ -n "$COMMENT_BODY" ]]; then
-            COMMENT_BODY="${COMMENT_BODY}"$'\n'"${line}"
-        else
-            COMMENT_BODY="${line}"
-        fi
+        COMMENT_BODY+="${COMMENT_BODY:+$'\n'}${line}"
     done
 else
     echo "エラー: コメント本文を指定してください。" >&2


### PR DESCRIPTION
## 概要

`thread-reply.sh`スクリプトでパイプ経由の標準入力が正しく読み取れない問題を修正し、引数指定とパイプ/ヒアドキュメント指定の両方に対応するハイブリッド方式に変更しました。

## 問題点

`echo "..." | ./thread-reply.sh <ID>` 形式でパイプ経由で標準入力を渡すと「コメント本文が空です」エラーが発生していました。

**原因**:
- `COMMENT_BODY=$(cat)` が特定の実行環境でパイプ経由の入力を正しく読み取れなかった
- `set -euo pipefail` オプションとの組み合わせで問題が発生

## 変更内容

### 1. 引数でのコメント指定を追加（推奨方法）
- `./thread-reply.sh "THREAD_ID" "コメント内容"` 形式をサポート
- 他のスクリプト（pr-create.sh等）と一貫性のある設計

### 2. パイプ/ヒアドキュメントも引き続きサポート
- `cat` から `read` コマンドに変更してパイプ経由の問題を解決
- 後方互換性を維持

### 3. 使用方法の更新
- ヘッダーコメントとusage関数を更新
- 引数での指定を推奨方法として明記

## 使用例

```bash
# 引数で指定（推奨）
./thread-reply.sh "THREAD_ID" "コメント内容"

# パイプで指定
echo "コメント内容" | ./thread-reply.sh "THREAD_ID"

# ヒアドキュメントで指定
./thread-reply.sh "THREAD_ID" <<EOF
複数行のコメント
EOF
```

## 変更ファイル

- `.claude/skills/github/scripts/thread-reply.sh` (+35行, -13行)