### PR TITLE
プレイヤーの移動を通路中心に制限する機能を実装

### DIFF
--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -260,29 +260,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.WALL, TileType.WALL, TileType.WALL, TileType.WALL],
         ];
         mockGameState.mapSize = 3;
-        mockGameState.exploredMap = [
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.EXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 3 }, () => Array(5).fill(ExplorationState.UNEXPLORED));
+          map[1][1] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーを水平通路に配置（Y座標が中心からずれている）
         mockGameState.player.x = 1.5;
@@ -314,13 +296,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.WALL, TileType.WALL],
         ];
         mockGameState.mapSize = 5;
-        mockGameState.exploredMap = [
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.EXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 5 }, () => Array(3).fill(ExplorationState.UNEXPLORED));
+          map[1][1] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーを垂直通路に配置（X座標が中心からずれている）
         mockGameState.player.x = 1.3; // 中心(1.5)からずれている
@@ -351,43 +331,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.WALL, TileType.FLOOR, TileType.WALL, TileType.WALL],
           [TileType.WALL, TileType.WALL, TileType.WALL, TileType.WALL, TileType.WALL],
         ];
-        mockGameState.exploredMap = [
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.EXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 5 }, () => Array(5).fill(ExplorationState.UNEXPLORED));
+          map[2][2] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーを交差点に配置（中心からずれている）
         mockGameState.player.x = 2.3;
@@ -418,29 +366,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.WALL, TileType.FLOOR, TileType.WALL, TileType.WALL],
         ];
         mockGameState.mapSize = 3;
-        mockGameState.exploredMap = [
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.EXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 3 }, () => Array(5).fill(ExplorationState.UNEXPLORED));
+          map[1][2] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーをT字路に配置（上側に寄っている: offsetY < 0.5）
         mockGameState.player.x = 2.5;
@@ -466,29 +396,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.WALL, TileType.FLOOR, TileType.WALL, TileType.WALL],
         ];
         mockGameState.mapSize = 3;
-        mockGameState.exploredMap = [
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.EXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-          [
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-            ExplorationState.UNEXPLORED,
-          ],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 3 }, () => Array(5).fill(ExplorationState.UNEXPLORED));
+          map[1][2] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーをT字路に配置（下側に寄っている: offsetY > 0.5）
         mockGameState.player.x = 2.5;
@@ -514,11 +426,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.FLOOR, TileType.WALL],
         ];
         mockGameState.mapSize = 3;
-        mockGameState.exploredMap = [
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.EXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 3 }, () => Array(3).fill(ExplorationState.UNEXPLORED));
+          map[1][1] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーをL字路に配置（左上に寄っている: offsetX < 0.5, offsetY < 0.5）
         mockGameState.player.x = 1.3; // セル内位置0.3 < 0.5なので左側に寄っている
@@ -545,11 +457,11 @@ describe('createRenderer', () => {
           [TileType.WALL, TileType.FLOOR, TileType.WALL],
         ];
         mockGameState.mapSize = 3;
-        mockGameState.exploredMap = [
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.EXPLORED, ExplorationState.UNEXPLORED],
-          [ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED, ExplorationState.UNEXPLORED],
-        ];
+        mockGameState.exploredMap = (() => {
+          const map = Array.from({ length: 3 }, () => Array(3).fill(ExplorationState.UNEXPLORED));
+          map[1][1] = ExplorationState.EXPLORED;
+          return map;
+        })();
 
         // プレイヤーをL字路に配置（右下に寄っている: offsetX > 0.5, offsetY > 0.5）
         mockGameState.player.x = 1.7; // セル内位置0.7 > 0.5なので右側に寄っている

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -65,24 +65,16 @@ function update(gameState: GameState, timerElement: HTMLElement): boolean {
     const topWall = getTile(gameState.map, cellX, cellY - 1) === TileType.WALL;
     const bottomWall = getTile(gameState.map, cellX, cellY + 1) === TileType.WALL;
 
-    // 左に壁があり、左側に寄りすぎている場合 → X座標を中心に補正
-    if (leftWall && offsetX < 0.5) {
-      gameState.player.x = cellX + 0.5;
+    const CELL_CENTER_OFFSET = 0.5;
+
+    // X座標の補正: 左右に壁があり、壁側に寄りすぎている場合
+    if ((leftWall && offsetX < CELL_CENTER_OFFSET) || (rightWall && offsetX > CELL_CENTER_OFFSET)) {
+      gameState.player.x = cellX + CELL_CENTER_OFFSET;
     }
 
-    // 右に壁があり、右側に寄りすぎている場合 → X座標を中心に補正
-    if (rightWall && offsetX > 0.5) {
-      gameState.player.x = cellX + 0.5;
-    }
-
-    // 上に壁があり、上側に寄りすぎている場合 → Y座標を中心に補正
-    if (topWall && offsetY < 0.5) {
-      gameState.player.y = cellY + 0.5;
-    }
-
-    // 下に壁があり、下側に寄りすぎている場合 → Y座標を中心に補正
-    if (bottomWall && offsetY > 0.5) {
-      gameState.player.y = cellY + 0.5;
+    // Y座標の補正: 上下に壁があり、壁側に寄りすぎている場合
+    if ((topWall && offsetY < CELL_CENTER_OFFSET) || (bottomWall && offsetY > CELL_CENTER_OFFSET)) {
+      gameState.player.y = cellY + CELL_CENTER_OFFSET;
     }
 
     // 探索済みタイルを更新


### PR DESCRIPTION
## 概要
プレイヤーが壁に近づきすぎて移動しづらい問題を解決するため、壁に接近した場合に自動的に通路中心へ補正する機能を実装しました。

## 変更内容
- プレイヤーの移動後、周囲の壁を判定して位置を補正するロジックを追加
- 壁がある方向に近づきすぎた場合のみ中心に補正することで、自然な操作感を実現
- テストケースを追加して動作を保証

## 実装詳細
以下の条件で通路中心への補正を実施：

1. **左に壁があり、左側に寄っている（offsetX < 0.5）** → X座標を中心に補正
2. **右に壁があり、右側に寄っている（offsetX > 0.5）** → X座標を中心に補正
3. **上に壁があり、上側に寄っている（offsetY < 0.5）** → Y座標を中心に補正
4. **下に壁があり、下側に寄っている（offsetY > 0.5）** → Y座標を中心に補正

この実装により、以下の特性を持ちます：
- 直線通路だけでなく、T字路やL字路（曲がり角）でも適切に動作
- 通路がある方向には自由に移動可能
- 壁に接近しすぎた場合のみ補正が働くため、操作性を損なわない

## 変更ファイル
- `src/renderer/index.ts` - `update()`関数に通路中心補正ロジックを追加
- `src/renderer/index.test.ts` - テストケースを追加

## テスト結果
- ✅ 全65テスト合格
- ✅ ビルド成功
- ✅ lint/formatチェック通過
