### PR TITLE
迷路のゴール位置をランダム化する機能を実装

### DIFF
--- a/frontend/src/maze/generator.test.ts
+++ b/frontend/src/maze/generator.test.ts
@@ -1,4 +1,4 @@
-import { TileType } from '@maze-runner/lib';
+import { type MazeMap, TileType } from '@maze-runner/lib';
 import { generateMaze } from './generator';
 
 describe('generateMaze', () => {
@@ -38,6 +38,17 @@ describe('generateMaze', () => {
   });
 
   describe('ゴール位置のランダム化', () => {
+    const findGoal = (maze: MazeMap): { x: number; y: number } | null => {
+      for (let y = 0; y < maze.length; y++) {
+        for (let x = 0; x < maze[y].length; x++) {
+          if (maze[y][x] === TileType.GOAL) {
+            return { x, y };
+          }
+        }
+      }
+      return null;
+    };
+
     it('ゴールがスタート地点(1,1)とは異なる位置にあること', () => {
       const size = 11;
       const maze = generateMaze(size);
@@ -48,49 +59,24 @@ describe('generateMaze', () => {
       const size = 11;
       const maze = generateMaze(size);
 
-      // ゴール位置を探す
-      let goalX = -1;
-      let goalY = -1;
-      for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-          if (maze[y][x] === TileType.GOAL) {
-            goalX = x;
-            goalY = y;
-            break;
-          }
-        }
-        if (goalX !== -1) break;
-      }
+      const goal = findGoal(maze);
+      expect(goal).not.toBeNull();
 
       // ゴールが外周でないことを確認(通路エリア内にあること)
-      expect(goalX).toBeGreaterThan(0);
-      expect(goalX).toBeLessThan(size - 1);
-      expect(goalY).toBeGreaterThan(0);
-      expect(goalY).toBeLessThan(size - 1);
+      expect(goal!.x).toBeGreaterThan(0);
+      expect(goal!.x).toBeLessThan(size - 1);
+      expect(goal!.y).toBeGreaterThan(0);
+      expect(goal!.y).toBeLessThan(size - 1);
     });
 
     it('ゴールとスタートのマンハッタン距離が迷路サイズの50%以上であること', () => {
       const size = 11;
       const maze = generateMaze(size);
 
-      // ゴール位置を探す
-      let goalX = -1;
-      let goalY = -1;
-      for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-          if (maze[y][x] === TileType.GOAL) {
-            goalX = x;
-            goalY = y;
-            break;
-          }
-        }
-        if (goalX !== -1) break;
-      }
+      const goal = findGoal(maze);
+      expect(goal).not.toBeNull();
 
-      expect(goalX).not.toBe(-1);
-      expect(goalY).not.toBe(-1);
-
-      const manhattanDistance = Math.abs(goalX - 1) + Math.abs(goalY - 1);
+      const manhattanDistance = Math.abs(goal!.x - 1) + Math.abs(goal!.y - 1);
       expect(manhattanDistance).toBeGreaterThanOrEqual(size * 0.5);
     });
 
@@ -101,21 +87,10 @@ describe('generateMaze', () => {
       for (let i = 0; i < iterations; i++) {
         const maze = generateMaze(size);
 
-        // ゴール位置を探す
-        let goalX = -1;
-        let goalY = -1;
-        for (let y = 0; y < size; y++) {
-          for (let x = 0; x < size; x++) {
-            if (maze[y][x] === TileType.GOAL) {
-              goalX = x;
-              goalY = y;
-              break;
-            }
-          }
-          if (goalX !== -1) break;
-        }
+        const goal = findGoal(maze);
+        expect(goal).not.toBeNull();
 
-        const manhattanDistance = Math.abs(goalX - 1) + Math.abs(goalY - 1);
+        const manhattanDistance = Math.abs(goal!.x - 1) + Math.abs(goal!.y - 1);
         expect(manhattanDistance).toBeGreaterThanOrEqual(size * 0.5);
       }
     });


### PR DESCRIPTION
## 概要

Issue #75の対応として、迷路のゴール位置をランダム化する機能を実装しました。従来は固定位置（右下）にゴールが配置されていましたが、毎回異なる位置にランダム配置することで、ゲームプレイの予測可能性を低減し難易度を向上させます。

## 変更内容

### `frontend/src/maze/generator.ts`
- `manhattanDistance` 関数を追加（マンハッタン距離計算）
- ゴール位置のランダム配置ロジックを実装
  - 迷路生成後、すべての通路座標を収集
  - スタート地点(1,1)との距離が迷路サイズの50%以上の候補をフィルタリング
  - 候補からランダムに1つ選択してゴールに設定
  - 候補がない場合は既存の固定位置 `(size-2, size-2)` にフォールバック

### `frontend/src/maze/generator.test.ts`
- ゴール位置ランダム化に関するテストケースを追加
  - ゴールが1つだけ存在すること
  - ゴールがスタート地点とは異なる位置にあること
  - ゴールが外周ではなく内部に配置されていること
  - マンハッタン距離の条件を満たすこと
  - 複数回生成しても距離条件を満たすこと

## テスト計画

- [x] ユニットテストが通過すること
- [ ] E2Eテストが通過すること（`npm run test:e2e`）
- [ ] 迷路を複数回生成してゴール位置が毎回異なることを確認
- [ ] スタートとゴールの距離が適切に確保されていることを目視確認
- [ ] UIの視覚表現（ゴールの色・表示）が維持されていることを確認
- [ ] 小さいサイズ（5x5など）の迷路でも正常に動作することを確認

## 関連Issue

Closes #75
