### PR TITLE
トップページメニューのクリアタイム表示を削除する

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,8 +18,6 @@
     <button class="diff-btn easy" data-size="11">初級 (11x11)</button>
     <button class="diff-btn normal" data-size="17">中級 (17x17)</button>
     <button class="diff-btn hard" data-size="23">上級 (23x23)</button>
-    <div id="last-score"></div>
-
     <!-- ランキングを見るボタン -->
     <button id="show-ranking-btn" class="show-ranking-btn">ランキングを見る</button>
 </div>

--- a/frontend/src/game/state.ts
+++ b/frontend/src/game/state.ts
@@ -108,11 +108,6 @@ export function win(deps: WinDependencies): void {
   const score = parseFloat(((Date.now() - deps.gameState.startTime) / 1000).toFixed(2));
   const difficulty = deps.getDifficultyFromSize(deps.gameState.mapSize);
 
-  const lastScoreElement = document.getElementById('last-score');
-  if (lastScoreElement) {
-    lastScoreElement.innerHTML = `<h2>CLEAR! クリアタイム: ${score.toFixed(2)}秒</h2>`;
-  }
-
   // スコア登録モーダルを表示
   deps.showScoreModal(score, difficulty, () => {
     // モーダル完了後にメニュー画面を表示


### PR DESCRIPTION
## Summary

- `win`関数内の`#last-score`要素にクリアタイムを設定する処理を削除
- `index.html`から`#last-score` div要素を削除

## 変更ファイル

- `frontend/src/game/state.ts`: win関数からクリアタイム表示処理（4行）を削除
- `frontend/index.html`: `<div id="last-score"></div>`要素を削除

## 影響範囲

- ゴール直後のスコアモーダル → 影響なし（変更対象外）
- ランキング画面 → 影響なし（変更対象外）
- トップページメニュー → クリアタイム表示が非表示になる

## Test plan

- [x] 既存ユニットテスト（176件）が全て通ることを確認済み
- [ ] ゴール直後のスコアモーダルにクリアタイムが表示されること
- [ ] トップページのメニュー画面にクリアタイムが表示されないこと
- [ ] ランキング画面のクリアタイム表示に影響がないこと

Closes #102

https://claude.ai/code/session_011rHcDKCpAdF2JvQZLQhL4G