### PR TITLE
GitHub MCP設定を削除しghコマンドに統一する (#164)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,16 +68,6 @@
       "Skill(run)",
       "WebSearch",
       "mcp__playwright",
-      "mcp__github__issue_read",
-      "mcp__github__issue_write",
-      "mcp__github__list_pull_requests",
-      "mcp__github__search_pull_requests",
-      "mcp__github__pull_request_read",
-      "mcp__github__create_pull_request",
-      "mcp__github__sub_issue_write",
-      "mcp__github__merge_pull_request",
-      "mcp__github__get_me",
-      "mcp__github__get_file_contents",
       "Skill(check-story-status)"
     ],
     "deny": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,13 +4,6 @@
       "type": "stdio",
       "command": "npx",
       "args": ["@playwright/mcp@latest", "--browser", "firefox"]
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GH_TOKEN}"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.mcp.json` からGitHub MCPサーバーの設定（`"github"` エントリ）を削除
- `.claude/settings.json` の `permissions.allow` から `mcp__github__*` の許可設定を全て削除
- `CLAUDE.md` は既にghコマンド統一済みのため変更不要

## Test plan
- [ ] `.mcp.json` にGitHub MCPサーバーの設定が残っていないこと
- [ ] `.claude/settings.json` に `mcp__github__*` の許可設定が残っていないこと
- [ ] プロジェクト全体で `mcp__github` への参照が残っていないこと

fixed #164