### PR TITLE
sub-issue-add.shからreplaceParentIssueパラメータを削除

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -152,11 +152,7 @@ EOF
 ### サブIssue追加
 
 ```bash
-# 基本的な使用法
 ./.claude/skills/github/scripts/sub-issue-add.sh <親Issue番号> <サブIssue番号>
-
-# 既存の親Issueを置換する場合
-./.claude/skills/github/scripts/sub-issue-add.sh <親Issue番号> <サブIssue番号> --replace-parent
 ```
 
 ## PR操作


### PR DESCRIPTION
## 概要
GitHub APIがサポートしていない`replaceParentIssue`パラメータによりサブIssue追加が常に失敗していた問題を修正しました。

## 変更内容
- `sub-issue-add.sh`から`replaceParentIssue`パラメータと`--replace-parent`オプション関連コードを削除
- `SKILL.md`から`--replace-parent`オプションのドキュメントを削除

fixed #174