### PR TITLE
githubスキルのdescriptionに各操作の使用スクリプト名を明記

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -5,17 +5,23 @@ description: |
   全操作がスクリプト版（.claude/skills/github/scripts/）で提供される。
   使用ケース:
   （1）リポジトリ情報取得 → repo-info.sh
-  （2）issue取得/作成/更新 → issue-get.sh / issue-create.sh / issue-update.sh
-  （3）サブIssue操作 → issue-sub-issues.sh / sub-issue-add.sh
-  （4）PR作成（事前チェック統合） → pr-create.sh
-  （5）PR検索/詳細取得 → pr-search.sh / pr-get.sh
-  （6）現在ブランチのPR番号取得 → pr-number.sh
-  （7）PRのCI状態取得 → pr-checks.sh / pr-status.sh
-  （8）PRマージ → pr-merge.sh
-  （9）レビュースレッド一覧/詳細取得 → thread-list.sh / thread-details.sh
-  （10）スレッド返信 → thread-reply.sh
-  （11）スレッド解決（resolve） → thread-resolve.sh
-  （12）ワークフローのログ取得 → workflow-log.sh
+  （2）issue取得 → issue-get.sh
+  （3）issue作成 → issue-create.sh
+  （4）issue更新 → issue-update.sh
+  （5）サブIssue一覧取得 → issue-sub-issues.sh
+  （6）サブIssue追加 → sub-issue-add.sh
+  （7）PR作成（事前チェック統合） → pr-create.sh
+  （8）PR検索 → pr-search.sh
+  （9）PR詳細取得 → pr-get.sh
+  （10）現在ブランチのPR番号取得 → pr-number.sh
+  （11）PRのCI状態取得 → pr-checks.sh
+  （12）PRのステータス取得 → pr-status.sh
+  （13）PRマージ → pr-merge.sh
+  （14）レビュースレッド一覧取得 → thread-list.sh
+  （15）レビュースレッド詳細取得 → thread-details.sh
+  （16）スレッド返信 → thread-reply.sh
+  （17）スレッド解決（resolve） → thread-resolve.sh
+  （18）ワークフローのログ取得 → workflow-log.sh
   注意: PR・Issueの本文に複数行テキストを含む場合はgh CLI + HEREDOCを使用すること
 ---
 


### PR DESCRIPTION
## 概要

fixed #121

githubスキルのYAMLフロントマターdescriptionフィールドを改善し、各操作で使用するスクリプト名を明記しました。

## 変更内容

- descriptionに全12操作とそれぞれの使用スクリプト名を明記
  - リポジトリ情報取得、issue操作、サブIssue操作、PR操作、レビュー操作、CI/CD操作、PR検索/詳細/マージを網羅
- 「全操作がスクリプト版（.claude/skills/github/scripts/）で提供される」ことを明記
- 複数行テキストの取り扱いに関する注意事項を追加
  - PR・Issueの本文に複数行テキストを含む場合は`gh CLI + HEREDOC`を使用するよう記載

## 注意事項

この変更により、スキル使用時に各操作で使用すべきスクリプトが明確になり、エージェントがより正確にスクリプトを選択できるようになります。