### PR TITLE
Issue管理系コマンドをスキル形式に移行

### DIFF
--- a/.claude/skills/assign-tasks/SKILL.md
+++ b/.claude/skills/assign-tasks/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: assign-tasks
-description: |
-  ユーザーストーリーのサブIssueにassign-to-claudeラベルを付与してClaudeにアサインします。
+description: ユーザーストーリーのサブIssueにassign-to-claudeラベルを付与してClaudeにアサインします。
 argument-hint: "[ユーザーストーリーのIssue番号]"
 ---
 

--- a/.claude/skills/breakdown-story/SKILL.md
+++ b/.claude/skills/breakdown-story/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: breakdown-story
-description: |
-  ユーザーストーリーを実装タスクに細分化し、GitHub Issueとして登録します。
+description: ユーザーストーリーを実装タスクに細分化し、GitHub Issueとして登録します。
 argument-hint: "[ユーザーストーリーのIssue番号]"
 ---
 

--- a/.claude/skills/optimize-issue-labels/SKILL.md
+++ b/.claude/skills/optimize-issue-labels/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: optimize-issue-labels
-description: |
-  GitHub Issueのラベル（story/task）を内容に基づいて最適化します。
+description: GitHub Issueのラベル（story/task）を内容に基づいて最適化します。
 argument-hint: "<Issue番号...>"
 ---
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan-issue
-description: |
-  GitHub Issueを作成します。story/taskラベルを内容に応じて自動付与します。
+description: GitHub Issueを作成します。story/taskラベルを内容に応じて自動付与します。
 ---
 
 ## 概要


### PR DESCRIPTION
## 概要
Issue管理系コマンド4つをスキル形式に移行し、統一的な管理を可能にします。

## 変更内容
- 以下の4コマンドを `.claude/commands/` から `.claude/skills/<name>/SKILL.md` に移行
  - `plan-issue` → `.claude/skills/plan-issue/SKILL.md`
  - `breakdown-story` → `.claude/skills/breakdown-story/SKILL.md`
  - `optimize-issue-labels` → `.claude/skills/optimize-issue-labels/SKILL.md`
  - `assign-tasks` → `.claude/skills/assign-tasks/SKILL.md`
- 各SKILL.mdにYAMLフロントマター（name, description、必要に応じてargument-hint）を追加
- 元の `.claude/commands/` 配下の4ファイルを削除

fixed #236