### PR TITLE
受け入れ確認スキル(verifying-acceptance)を作成する (#342)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,7 +40,7 @@
 |---|---|---|
 | 呼び出し層（invocation） | 外部からスキルを起動する自動化スクリプト | `scripts/schedule.sh` |
 | ワークフロー層（workflow） | ユーザー起動専用。他スキルを組み合わせて実行する統合スキル | `running-dev`, `running-refinement` |
-| 機能層（feature） | 独立した単機能スキル | `coding`, `reviewing`, `creating-pr`, `fixing-pr`, `requesting`, `breaking-down-story`, `optimizing-issue-labels`, `running-retro`, `solving-issue` |
+| 機能層（feature） | 独立した単機能スキル | `coding`, `reviewing`, `creating-pr`, `fixing-pr`, `requesting`, `breaking-down-story`, `optimizing-issue-labels`, `running-retro`, `solving-issue`, `verifying-acceptance` |
 | 基盤層（foundation） | 他スキルから共通利用されるインフラスキル | `managing-github` |
 
 ### 依存ルール

--- a/.claude/skills/verifying-acceptance/SKILL.md
+++ b/.claude/skills/verifying-acceptance/SKILL.md
@@ -11,17 +11,17 @@ argument-hint: "[ストーリーのIssue番号]"
     - 引数で指定されている場合、その番号を使用する。
     - 引数が未指定の場合は「ストーリーのIssue番号を指定してください」とユーザーに通知し、処理を終了する。
 
-2. `github` スキルでストーリーIssueの情報を取得する。
+2. `managing-github` スキルでストーリーIssueの情報を取得する。
     - Issue本文から受け入れ条件（チェックボックス形式 `- [ ]`）を抽出する。
     - 受け入れ条件が存在しない場合は「受け入れ条件が定義されていません」とユーザーに通知し、処理を終了する。
 
-3. `github` スキル（`issue-sub-issues.sh`）でサブIssueの一覧を取得する。
+3. `managing-github` スキルの `issue-sub-issues.sh` でサブIssueの一覧を取得する。
     - 各サブIssueのタイトル、状態（OPEN/CLOSED）、本文を確認する。
 
 4. 実装されたソースコードを確認する。
     - サブIssueで言及されているファイルや変更内容を確認する。
     - 最近のコミット履歴を確認する（`git log` コマンド）。
-    - 関連するPRがあればその内容を確認する。
+    - 関連するPRがあれば `managing-github` スキルの `pr-get.sh` で内容を確認する。
 
 5. 各受け入れ条件について、満たされているか判定する。
     - 完了したサブIssueの実装内容を元に判定する。
@@ -31,14 +31,14 @@ argument-hint: "[ストーリーのIssue番号]"
 6. 判定結果に応じて処理を実行する。
     - **満たされていない受け入れ条件がある場合**:
         - 満たされていない各条件について、追加タスクを作成する必要があるか検討する。
-        - 追加タスクが必要な場合、`document-specialist` エージェントに依頼してタスクのIssue本文を「追加タスクIssue作成ルール」に従って生成する。
-        - `github` スキル（`issue-create.sh`）でIssueを作成する。`--label task` オプションを付与して `task` ラベルを自動付与すること。
-        - `github` スキル（`sub-issue-add.sh`）でストーリーIssueのサブissueとして登録する。
+        - 追加タスクが必要な場合、タスクのIssue本文を「追加タスクIssue作成ルール」に従って生成する。
+        - `managing-github` スキルの `issue-create.sh` でIssueを作成する。`--label task` オプションを付与して `task` ラベルを自動付与すること。
+        - `managing-github` スキルの `sub-issue-add.sh` でストーリーIssueのサブissueとして登録する。
         - 作成した追加タスクの一覧（タイトル・URL・理由）をユーザーに報告する。
     - **すべての受け入れ条件を満たしている場合**:
         - 現在のGitHubユーザー名を取得する（`gh api user --jq '.login'` コマンド）。
-        - `github` スキル（`issue-update.sh`）でストーリーIssueにユーザーをassigneeとして追加する（`--add-assignee` オプション）。
-        - `github` スキル（`issue-add-comment.sh`）でストーリーIssueに受け入れ完了のコメントを追加する。コメント内容は以下の形式とする：
+        - `managing-github` スキルの `issue-update.sh` でストーリーIssueにユーザーをassigneeとして追加する（`--add-assignee` オプション）。
+        - `managing-github` スキルの `issue-add-comment.sh` でストーリーIssueに受け入れ完了のコメントを追加する。コメント内容は以下の形式とする：
             ```
             ## 受け入れ確認完了
 


### PR DESCRIPTION
## 概要

ストーリーの受け入れ条件を確認し、未達の場合は追加タスクを作成、達成済みの場合はユーザーをassigneesに追加する機能層スキル `verifying-acceptance` を作成しました。

## 変更内容

- `.claude/skills/verifying-acceptance/SKILL.md` を新規作成
  - ストーリーIssueの受け入れ条件取得機能
  - サブIssueとソースコードの確認による条件達成判定
  - 未達条件に対する追加タスク作成機能
  - 全条件達成時のユーザーassignees追加機能
- `.claude/CLAUDE.md` の機能層リストに `verifying-acceptance` を追加

## 依存関係

- 層: 機能層（feature）
- 依存先: 基盤層（managing-github）のみ
- 機能層同士の依存なし

## 注意事項

- このスキルは引数としてストーリーのIssue番号を受け取ります
- 受け入れ条件の判定は、サブIssueの状態とソースコードの実装内容を総合的に評価します
- 追加タスク作成時はストーリーにサブIssueとして紐づけられます

Closes #342