### PR TITLE
タスクアサイン時にassigneesなしのストーリーのみ取得

### DIFF
--- a/scripts/schedule.sh
+++ b/scripts/schedule.sh
@@ -109,9 +109,9 @@ breakdown_stories() {
 assign_tasks() {
   log "タスクアサインをチェックします..."
 
-  # 全openストーリーを取得（作成日の古い順）
+  # assigneesが設定されていないopenストーリーを取得（作成日の古い順）
   local stories_json
-  if ! stories_json=$(gh issue list --label story --state open --limit 100 --json number,createdAt 2>&1); then
+  if ! stories_json=$(gh issue list --label story --state open --search "no:assignee" --limit 100 --json number,createdAt 2>&1); then
     log "ストーリー一覧の取得に失敗しました: $stories_json" >&2
     return 1
   fi


### PR DESCRIPTION
## 概要
`schedule.sh`のタスクアサイン処理で、assigneesが設定されたストーリー（受け入れ確認中）を除外するように変更。

## 変更内容
`assign_tasks` 関数で `gh issue list` に `--search "no:assignee"` を追加し、assigneesなしのopenストーリーのみを取得。

## 効果
- 開発側が対応すべきストーリーだけをタスクアサイン対象とする
- 受け入れ確認の完了を待たずに、次の開発タスクに効率的に着手できる

fixed #355