### PR TITLE
running-refinementを共通フロー構成に統一しスキル委譲に変更

### DIFF
--- a/.claude/skills/running-refinement/SKILL.md
+++ b/.claude/skills/running-refinement/SKILL.md
@@ -25,7 +25,7 @@ layer: workflow
 
 このフェーズでは `/optimizing-issue-labels` スキルを使用して、トリアージとラベル最適化を一括で実行する。
 
-1. `github` スキルを使用してオープン状態のIssue一覧を取得する（`gh issue list --repo "${OWNER}/${REPO}" --state open --json number,labels --limit 100`）。
+1. `github` スキルを使用してオープン状態のIssue一覧を取得する（`gh issue list --repo "${OWNER}/${REPO}" --state open --json number,title,labels --limit 100`）。
 2. `story` および `task` ラベルがいずれも付与されていないIssueを抽出する。
 3. 対象Issueの一覧を報告する。
    - 対象が0件の場合は「対象なし」と報告し、フェーズ2に進む。


### PR DESCRIPTION
## 概要

`running-refinement` スキルのSKILL.mdを、`schedule.sh`と共通のフロー構成・ロジックに全面的に書き換えました。インライン実装をスキル委譲に置き換え、フェーズ順序・処理件数・タスクアサインロジックを統一することで、保守性と一貫性を向上させます。

## 変更内容

### フェーズ順序の変更
- フェーズ順序を以下に統一:
  1. ラベル最適化（トリアージ統合済み）
  2. 受け入れ確認（フィードバック確認統合済み）
  3. タスクアサイン
  4. ストーリー細分化

### 各フェーズの実装変更
- **ラベル最適化**: インライン実装（旧フェーズ0+1）を削除し、`/optimizing-issue-labels` スキルへの委譲に変更
- **受け入れ確認**: インライン実装（旧フェーズ4の受け入れ条件チェック）を削除し、`/verifying-acceptance` スキルへの委譲に変更
- **タスクアサイン**: 7段階検証を削除し、`schedule.sh`の優先順位制御ロジックに統一。処理件数を1件に変更。`assign-to-claude` ラベルを付与
- **ストーリー細分化**: インライン実装を削除し、`/breaking-down-story` スキルへの委譲に変更。処理件数を1件に変更
- 旧フェーズ3（ストーリーフィードバック確認）を削除

### その他の変更
- 最終報告セクションとチェックリストを更新
- 変更統計: 83行追加、169行削除

## 関連Issue

Closes #368

https://claude.ai/code/session_019koZGE5RjkHSfkRcSnLWkH