### PR TITLE
reviewingスキルにスキルファイル品質のレビュー観点を追加

### DIFF
--- a/.claude/skills/reviewing/SKILL.md
+++ b/.claude/skills/reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing
-description: コーディング規約、テスト配置、ファイル構造、ドキュメント品質の観点からコードレビューを実行します。実装完了後のコードレビューやPR作成前の最終確認で使用してください。
+description: コーディング規約、テスト配置、ファイル構造、ドキュメント品質、スキルファイル品質の観点からコードレビューを実行します。実装完了後のコードレビューやPR作成前の最終確認で使用してください。
 layer: feature
 ---
 
@@ -12,6 +12,7 @@ layer: feature
 - **テストルール**: `testing-specialist`
 - **構造ルール**: `structure-specialist`
 - **ドキュメント品質**: `document-specialist`
+- **スキルファイル品質**: `skill-specialist`
 
 ## 注意事項
 


### PR DESCRIPTION
## 概要

Issue #333 に対応し、reviewingスキルのレビュー観点に「スキルファイル品質」を追加しました。

従来、reviewingスキルはコーディング規約、テストルール、構造ルール、ドキュメント品質のレビュー観点を持っていましたが、スキルファイル自体のレビュー観点が含まれていませんでした。この変更により、スキルファイルの修正時にも `skill-specialist` による適切なレビューが実施されるようになります。

## 変更内容

- `.claude/skills/reviewing/SKILL.md` を更新
  - description に「スキルファイル品質」のレビュー観点を追加
  - レビュー観点リストに「**スキルファイル品質**: `skill-specialist`」を追加

## テスト方法

- [ ] `.claude/skills/reviewing/SKILL.md` の内容を確認し、スキルファイル品質のレビュー観点が追加されていることを確認
- [ ] description とレビュー観点リストの両方に追加されていることを確認
- [ ] 他のレビュー観点（コーディング規約、テストルール等）と整合性のある記述になっていることを確認

Fixes #333

https://claude.ai/code/session_012UYiLm15KDDSt4fqBzBZMT