### PR TITLE
claude --remoteコマンド失敗時にラベルを自動削除する処理を追加

### DIFF
--- a/scripts/schedule.sh
+++ b/scripts/schedule.sh
@@ -201,7 +201,11 @@ assign_tasks() {
         return 1
       fi
 
-      claude --remote "/running-dev ${available_task}"
+      if ! claude --remote "/running-dev ${available_task}"; then
+        log "エラー: タスク #${available_task} の実行に失敗しました" >&2
+        ./.claude/skills/managing-github/scripts/issue-update.sh "${available_task}" --remove-label "$IN_PROGRESS_LABEL" --remove-label "$ASSIGN_LABEL" 2>&1 || true
+        return 1
+      fi
       log "タスク #${available_task} のアサインが完了しました"
       return 0
     fi
@@ -271,7 +275,11 @@ assign_tasks() {
         return 1
       fi
 
-      claude --remote "/running-dev ${available_task}"
+      if ! claude --remote "/running-dev ${available_task}"; then
+        log "エラー: タスク #${available_task} の実行に失敗しました" >&2
+        ./.claude/skills/managing-github/scripts/issue-update.sh "${available_task}" --remove-label "$IN_PROGRESS_LABEL" --remove-label "$ASSIGN_LABEL" 2>&1 || true
+        return 1
+      fi
       log "タスク #${available_task} のアサインが完了しました"
       return 0
     fi
@@ -286,7 +294,11 @@ assign_tasks() {
       return 1
     fi
 
-    claude --remote "/running-dev ${target_number}"
+    if ! claude --remote "/running-dev ${target_number}"; then
+      log "エラー: タスク #${target_number} の実行に失敗しました" >&2
+      ./.claude/skills/managing-github/scripts/issue-update.sh "${target_number}" --remove-label "$IN_PROGRESS_LABEL" --remove-label "$ASSIGN_LABEL" 2>&1 || true
+      return 1
+    fi
     log "タスク #${target_number} のアサインが完了しました"
     return 0
   fi


### PR DESCRIPTION
## Summary
- `scripts/schedule.sh` の3箇所で `claude --remote` コマンドの失敗を検知し、自動でラベルを削除する処理を追加
- 失敗時には `in-progress-by-claude` と `assign-to-claude` ラベルを削除することで、タスクの状態を正常に戻す
- エラーログ出力、ラベル削除、戻り値設定を統一的に実装

## Test plan
- [ ] 進行中ストーリーの子タスクアサイン時に claude --remote が失敗した場合、ラベルが削除されることを確認
- [ ] 未着手ストーリーの子タスクアサイン時に claude --remote が失敗した場合、ラベルが削除されることを確認
- [ ] 親なしタスクアサイン時に claude --remote が失敗した場合、ラベルが削除されることを確認
- [ ] エラーログに対象タスク番号が含まれることを確認
- [ ] ラベル削除が正常に動作することを確認

fixed #430

---
*このPRは [Claude Code](https://claude.ai/code) により自動作成されました*