### PR TITLE
creating-prスキルのPR作成手順を明確化

### DIFF
--- a/.claude/skills/creating-pr/SKILL.md
+++ b/.claude/skills/creating-pr/SKILL.md
@@ -9,7 +9,8 @@ layer: feature
 2. 作業ブランチにコミットされた修正内容を把握する。
 3. プルリクエストのタイトルと本文を作成する。
     - `document-specialist` エージェントと協力して作成すること。
-4. `managing-github` スキルを使用してプルリクエストを作成する。
+4. `managing-github` スキルの `scripts/pr-create.sh` を使用してプルリクエストを作成する。
+    - 詳細な使用方法は `.claude/skills/managing-github/PR-OPERATIONS.md` の「PR作成」セクションを参照
 5. PR作成後の検証と自動修正を行う。
     - 手順3で作成したタイトルと本文を変数に保持しておく
     - `managing-github` スキルの `scripts/pr-get.sh` で作成したPRの実際の情報を取得する


### PR DESCRIPTION
## Summary

`creating-pr/SKILL.md` の手順4にスクリプト名と参照先を追加し、PR作成方法を明確化しました。

## 変更内容

- `.claude/skills/creating-pr/SKILL.md` の手順4を以下のように修正
  - 変更前：「`managing-github` スキルを使用してプルリクエストを作成する」
  - 変更後：「`managing-github` スキルの `scripts/pr-create.sh` を使用してプルリクエストを作成する」と明記
  - PR-OPERATIONS.md の「PR作成」セクションへの参照を追加

## 目的

Issue #368 の対応時に、手順に具体的な使用方法が記載されていなかったため、誤った方法でPRを作成するエラーが発生しました。この変更により同様のエラーを防止します。

## 確認事項

- [ ] 手順4の記載が具体的で理解しやすいか
- [ ] PR-OPERATIONS.md への参照が正しいか
- [ ] 他のスキルドキュメントとの整合性が取れているか

fixed #410

---
*このPRは [Claude Code](https://claude.ai/code) により自動作成されました*