### PR TITLE
codingスキルでタスク内容に応じた適切なエージェント選択機能を追加

### DIFF
--- a/.claude/skills/coding/SKILL.md
+++ b/.claude/skills/coding/SKILL.md
@@ -11,5 +11,18 @@ argument-hint: [GitHub Issueの番号]
 2. `managing-github` スキルでGitHub Issueの内容を把握する。
 3. 対応を行う。
     - Issue内容に基づいて実装計画を策定する。
-    - `coding-specialist` エージェントと協力して実装を行う。
+    - タスク内容に応じて適切なエージェントを選択して実装を行う。
+      - **ソースコード実装**: `coding-specialist`を使用
+        - TypeScript/JavaScript/CSS/HTMLファイルの作成・修正
+        - ロジックの実装
+        - テストコードの作成
+      - **ドキュメント作成**: `document-specialist`を使用
+        - Markdownファイル（README、ドキュメント、Issue、PR説明文など）の作成・修正
+        - 技術文書の作成
+        - API仕様書の作成
+      - **スキル作成・レビュー**: `skill-specialist`を使用
+        - `.claude/skills/` 配下のファイルの作成・修正
+      - **複合タスク**: 主要な作業内容に基づいて判断
+        - ドキュメント作成が主: `document-specialist`
+        - コード実装が主: `coding-specialist`
     - CLAUDE.mdに定義された品質チェック手順を実行し、問題があれば実装の修正に戻る。

--- a/.claude/skills/coding/SKILL.md
+++ b/.claude/skills/coding/SKILL.md
@@ -25,4 +25,5 @@ argument-hint: [GitHub Issueの番号]
       - **複合タスク**: 主要な作業内容に基づいて判断
         - ドキュメント作成が主: `document-specialist`
         - コード実装が主: `coding-specialist`
+        - スキル作成が主: `skill-specialist`
     - CLAUDE.mdに定義された品質チェック手順を実行し、問題があれば実装の修正に戻る。


### PR DESCRIPTION
## Summary
- fixes #384
- `/coding` スキルでタスク内容に応じて適切なエージェント（`coding-specialist`、`document-specialist`、`skill-specialist`）を自動選択できるよう判断基準を追加
- ドキュメント作成タスクでは `document-specialist`、ソースコード実装では `coding-specialist`、スキル作成では `skill-specialist` を使用するように明記し、各エージェントの専門性を活かせるようにした

## Test plan
- [ ] `.claude/skills/coding/SKILL.md` の変更内容を確認し、判断基準が明確に記載されていることを確認
- [ ] ドキュメント作成タスク（例: README更新、API仕様書作成）で `/coding` スキルを実行し、`document-specialist` が選択されることを確認
- [ ] ソースコード実装タスク（例: TypeScript実装、テストコード作成）で `/coding` スキルを実行し、`coding-specialist` が選択されることを確認
- [ ] スキル作成・修正タスクで `/coding` スキルを実行し、`skill-specialist` が選択されることを確認
- [ ] 複合タスク（コードとドキュメント両方を含む）で主要な作業内容に基づいて適切なエージェントが選択されることを確認

---
*このPRは [Claude Code](https://claude.ai/code) により自動作成されました*
